### PR TITLE
Some cleanups

### DIFF
--- a/src/union_iter.rs
+++ b/src/union_iter.rs
@@ -156,9 +156,7 @@ where
                     continue;
                 }
             } else {
-                let result = self.option_range.clone();
-                self.option_range = None;
-                return result;
+                return self.option_range.take();
             }
         }
     }

--- a/src/union_iter.rs
+++ b/src/union_iter.rs
@@ -137,7 +137,7 @@ where
             if let Some(range) = self.iter.next() {
                 let (start, end) = range.into_inner();
                 if end < start {
-                    return self.next();
+                    continue;
                 }
                 if let Some(current_range) = self.option_range.clone() {
                     let (current_start, current_end) = current_range.into_inner();

--- a/src/unsorted_disjoint.rs
+++ b/src/unsorted_disjoint.rs
@@ -76,11 +76,8 @@ where
                     self.option_range = Some(next_start..=next_end);
                     continue;
                 }
-            } else if let Some(range) = self.option_range.clone() {
-                self.option_range = None;
-                return Some(range);
             } else {
-                return None;
+                return self.option_range.take();
             }
         }
     }

--- a/tests_common/src/lib.rs
+++ b/tests_common/src/lib.rs
@@ -148,27 +148,16 @@ impl<'a, T: Integer> MemorylessIter<'a, T> {
 impl<'a, T: Integer> Iterator for MemorylessIter<'a, T> {
     type Item = T;
 
-    #[allow(clippy::reversed_empty_ranges)]
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(range) = &self.option_range {
-                let (start, end) = range.clone().into_inner();
-                if start < end {
-                    self.option_range = Some(start + T::one()..=end);
-                } else {
-                    self.option_range = None;
-                    if start > end {
-                        continue; // skip empty ranges
-                    }
-                }
-                return Some(start);
-            } else if let Some(range) = self.iter.next() {
-                self.option_range = Some(range);
-                continue;
-            } else {
-                return None;
-            }
+        let range = self
+            .option_range
+            .take()
+            .or_else(|| self.iter.find(|range| range.start() <= range.end()))?;
+        let (start, end) = range.into_inner();
+        if start < end {
+            self.option_range = Some(start + T::one()..=end);
         }
+        Some(start)
     }
 }
 


### PR DESCRIPTION
- Evicted some loops/continue constructs with (hopefully) simpler code.
- Replaced `some_option.clone(); some_option = None;` with calls to `Option::take()` 
- Changed a recursive call to a already existing looping construct