### PR TITLE
enh: Implement DoubleEndedIterator for iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.15] - 2024-0209
+
+- Added DoubleEndedIterator when iterating integer elements. Thanks to enh.
+
 ## [0.1.14] - 2023-12-5
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "range-set-blaze"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "criterion",
  "gen_ops",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range-set-blaze"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "Integer sets as fast, sorted, integer ranges with full set operations"
 repository = "https://github.com/CarlKCarlK/range-set-blaze"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,8 +401,8 @@ impl<T: Integer> fmt::Display for RangeSetBlaze<T> {
 }
 
 impl<T: Integer> RangeSetBlaze<T> {
-    /// Gets an iterator that visits the integer elements in the [`RangeSetBlaze`] in ascending
-    /// order.
+    /// Gets an (double-ended) iterator that visits the integer elements in the [`RangeSetBlaze`] in
+    /// ascending and/or descending order.
     ///
     /// Also see the [`RangeSetBlaze::ranges`] method.
     ///
@@ -419,7 +419,8 @@ impl<T: Integer> RangeSetBlaze<T> {
     /// assert_eq!(set_iter.next(), None);
     /// ```
     ///
-    /// Values returned by the iterator are returned in ascending order:
+    /// Values returned by `.next()` are in ascending order.
+    /// Values returned by `.next_back()` are in descending order.
     ///
     /// ```
     /// use range_set_blaze::RangeSetBlaze;
@@ -427,9 +428,9 @@ impl<T: Integer> RangeSetBlaze<T> {
     /// let set = RangeSetBlaze::from_iter([3, 1, 2]);
     /// let mut set_iter = set.iter();
     /// assert_eq!(set_iter.next(), Some(1));
+    /// assert_eq!(set_iter.next_back(), Some(3));
     /// assert_eq!(set_iter.next(), Some(2));
-    /// assert_eq!(set_iter.next(), Some(3));
-    /// assert_eq!(set_iter.next(), None);
+    /// assert_eq!(set_iter.next_back(), None);
     /// ```
     pub fn iter(&self) -> Iter<T, RangesIter<T>> {
         // If the user asks for an iter, we give them a RangesIter iterator
@@ -1808,7 +1809,7 @@ impl<T: Integer> IntoIterator for RangeSetBlaze<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
-    /// Gets an iterator for moving out the [`RangeSetBlaze`]'s integer contents.
+    /// Gets a (double-ended) iterator for moving out the [`RangeSetBlaze`]'s integer contents.
     ///
     /// # Examples
     ///
@@ -1819,6 +1820,10 @@ impl<T: Integer> IntoIterator for RangeSetBlaze<T> {
     ///
     /// let v: Vec<_> = set.into_iter().collect();
     /// assert_eq!(v, [1, 2, 3, 4]);
+    ///
+    /// let set = RangeSetBlaze::from_iter([1, 2, 3, 4]);
+    /// let v: Vec<_> = set.into_iter().rev().collect();
+    /// assert_eq!(v, [4, 3, 2, 1]);
     /// ```
     fn into_iter(self) -> IntoIter<T> {
         IntoIter {
@@ -1829,7 +1834,7 @@ impl<T: Integer> IntoIterator for RangeSetBlaze<T> {
     }
 }
 
-/// An iterator over the integer elements of a [`RangeSetBlaze`].
+/// A (double-ended) iterator over the integer elements of a [`RangeSetBlaze`].
 ///
 /// This `struct` is created by the [`iter`] method on [`RangeSetBlaze`]. See its
 /// documentation for more.
@@ -1855,7 +1860,9 @@ where
 {
     type Item = T;
     fn next(&mut self) -> Option<T> {
-        let range = self.option_range_front.take()
+        let range = self
+            .option_range_front
+            .take()
             .or_else(|| self.iter.next())
             .or_else(|| self.option_range_back.take())?;
 
@@ -1877,10 +1884,12 @@ where
 
 impl<T: Integer, I> DoubleEndedIterator for Iter<T, I>
 where
-    I: SortedDisjoint<T> + DoubleEndedIterator
+    I: SortedDisjoint<T> + DoubleEndedIterator,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let range = self.option_range_back.take()
+        let range = self
+            .option_range_back
+            .take()
             .or_else(|| self.iter.next_back())
             .or_else(|| self.option_range_front.take())?;
         let (start, end) = range.into_inner();
@@ -1895,7 +1904,7 @@ where
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
-/// An iterator over the integer elements of a [`RangeSetBlaze`].
+/// A (double-ended) iterator over the integer elements of a [`RangeSetBlaze`].
 ///
 /// This `struct` is created by the [`into_iter`] method on [`RangeSetBlaze`]. See its
 /// documentation for more.

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -58,6 +58,13 @@ impl<'a, T: Integer> Iterator for RangesIter<'a, T> {
     }
 }
 
+impl<T: Integer> DoubleEndedIterator for RangesIter<'_, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+            .map(|(start, end)| *start..=*end)
+    }
+}
+
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 /// An iterator that moves out the ranges in the [`RangeSetBlaze`],
 /// i.e., the integers as sorted & disjoint ranges.
@@ -96,6 +103,14 @@ impl<T: Integer> Iterator for IntoRangesIter<T> {
         self.iter.size_hint()
     }
 }
+
+impl<T: Integer> DoubleEndedIterator for IntoRangesIter<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+            .map(|(start, end)| start..=end)
+    }
+}
+
 
 impl<T: Integer> ops::Not for RangesIter<'_, T> {
     type Output = NotIter<T, Self>;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1424,7 +1424,6 @@ fn demo_read() {
     let _a: RangeSetBlaze<i32> = demo_read_ranges_from_file("tests/no_such_file").unwrap();
 }
 
-
 #[test]
 fn double_end_iter() {
     let a = RangeSetBlaze::from_iter([3..=10, 12..=12, 20..=25]);
@@ -1455,7 +1454,7 @@ fn double_end_iter() {
     }
 }
 #[test]
-fn double_end_intoiter() {
+fn double_end_into_iter() {
     let a = RangeSetBlaze::from_iter([3..=10, 12..=12, 20..=25]);
 
     assert_eq!(


### PR DESCRIPTION
Hi, 

I had a need for the `range_set_blaze::IntoIter` type to implement DoubleEndedIterator. I saw in the code, however, that the implementation of that trait for all iterators was still on the todo list.

So here's my attempt to implement the DoubleEndedIterator trait for all range_set_blaze iterator types. The original iterator types store the the current range it's iterating over in a struct member `option_range`. To support iterating from both the front and the back (allowing mixed use of `next()` and `next_back()`), the new versions of the iterator types store two ranges: `option_range_front` and `option_range_back`. The functions `next()` and `next_back()`
then update those respective fields during iteration, also taking into account that at some point only a single range remains to iterate over.

Please let me know if you'd like to see any changes!