### PR TITLE
v0.4.2: SIMD compatibility + developer tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,182 @@
+# Contributing to range-set-blaze
+
+Thank you for your interest in contributing! This document provides information for developers working on the project.
+
+## Development Prerequisites
+
+- **Rust Stable**: For main development
+- **Rust Nightly**: For `from_slice` SIMD feature
+- **Just**: Task runner for local CI checks - Install: `cargo install just`
+- **Optional Tools** (installed automatically by relevant commands):
+  - `cargo-deadlinks`: For documentation link checking
+  - `cargo-audit`: For security audits
+  - `cargo-deny`: For license compliance
+
+## Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/CarlKCarlK/range-set-blaze.git
+cd range-set-blaze
+
+# Install just (if not already installed)
+cargo install just
+
+# See all available commands
+just --list
+
+# Run all checks before pushing (recommended!)
+just check-all
+```
+
+## Local Testing with Just
+
+We use **[Just](https://github.com/casey/just)** for local CI testing. This ensures your changes pass CI checks before pushing.
+
+### Most Common Commands
+
+```bash
+# Before pushing - run ALL checks (includes nightly tests)
+just check-all
+
+# Quick check before committing (stable only, faster)
+just pre-commit
+
+# Run only stable CI checks (what CI runs on stable)
+just ci
+
+# Run clippy with exact CI settings
+just clippy
+
+# Run all stable tests
+just test-stable
+
+# Run nightly tests (includes from_slice feature)
+just test-nightly
+```
+
+### SIMD Feature Commands
+
+The `from_slice` feature requires nightly Rust and uses SIMD:
+
+```bash
+# Build with SIMD feature
+just build-simd
+
+# Test with SIMD feature
+just test-simd
+```
+
+### Quality Checks
+
+```bash
+# Check documentation for broken links
+just doc-links
+
+# Audit dependencies for security & licenses
+just audit
+
+# Test publishing (dry run)
+just publish-dry-all
+
+# Full CI simulation (everything except WASM/embedded)
+just ci-full
+```
+
+### Utilities
+
+```bash
+# Format code
+just fmt
+
+# Check formatting
+just fmt-check
+
+# Clean build artifacts
+just clean
+```
+
+## Testing Locally Before CI
+
+**Always run `just check-all` or at minimum `just ci` before pushing!**
+
+This catches:
+- Clippy lints that fail CI with `-D clippy::all`
+- Test failures across different configurations
+- Formatting issues
+- Documentation problems
+
+### Why Local Testing Matters
+
+CI runs strict checks that regular `cargo test` doesn't:
+- **Clippy errors**: `cargo clippy -- -D clippy::all` treats ALL clippy warnings as errors
+- **Multiple configurations**: Tests with different feature combinations
+- **Release mode**: Tests in both debug and release
+- **Documentation**: Checks for broken links and missing docs
+
+Running `just check-all` replicates these checks locally, saving you from CI failures.
+
+## Understanding the CI Pipeline
+
+Our CI (`.github/workflows/ci.yml`) tests:
+
+1. **3 OS platforms**: Ubuntu, macOS, Windows
+2. **Multiple architectures**: 64-bit and 32-bit
+3. **WASM targets**: wasm32-unknown-unknown and wasm32-wasip1
+4. **Embedded**: thumbv7m-none-eabi (ARM Cortex-M)
+5. **Both toolchains**: Stable and Nightly
+6. **Security**: Dependency audits with cargo-audit and cargo-deny
+
+You can't replicate everything locally (WASM, embedded, multiple OSes), but `just check-all` covers the main issues.
+
+## Pull Request Process
+
+1. **Create a feature branch**: `git checkout -b feature/my-feature`
+2. **Make your changes**
+3. **Run local checks**: `just check-all`
+4. **Fix any issues** and commit
+5. **Push and create PR**: `git push origin feature/my-feature`
+6. **Wait for CI** to pass on GitHub
+7. **Address review feedback** if any
+8. **Merge** once approved and CI passes
+
+## Code Style
+
+- Run `just fmt` before committing
+- Follow existing code patterns
+- Add documentation for public APIs
+- Write tests for new functionality
+
+## Feature Flags
+
+The project has several optional features:
+
+- `std` (default): Standard library support
+- `from_slice`: SIMD-accelerated slice ingestion (nightly only)
+- `rog_experimental`: Experimental ROG (Range-of-Gaps) feature
+- `test_util`: Testing utilities (dev only)
+
+## Release Process
+
+(For maintainers)
+
+See the internal release notes, but in brief:
+
+1. Update version in `Cargo.toml`
+2. Update `CHANGELOG.md`
+3. Run `just ci-full` locally
+4. Run `just publish-dry-all`
+5. Create and merge PR
+6. Tag release: `git tag v0.x.y`
+7. Push tag: `git push origin v0.x.y`
+8. Publish: `cargo publish`
+
+## Getting Help
+
+- **Issues**: [GitHub Issues](https://github.com/CarlKCarlK/range-set-blaze/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/CarlKCarlK/range-set-blaze/discussions)
+- **Documentation**: [docs.rs](https://docs.rs/range-set-blaze)
+
+## License
+
+By contributing, you agree that your contributions will be dual-licensed under MIT OR Apache-2.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "range-set-blaze"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range-set-blaze"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Integer sets as fast, sorted integer ranges; Maps with integer-range keys; Full set operations"
 repository = "https://github.com/CarlKCarlK/range-set-blaze"

--- a/README.md
+++ b/README.md
@@ -204,3 +204,19 @@ for range in intron.ranges() {
     println!("{chrom}\t{start}\t{end}");
 }
 ```
+
+## Contributing
+
+Contributions are welcome! For development workflow, local testing, and CI information, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+**Quick start for developers:**
+```bash
+# Install just task runner
+cargo install just
+
+# Run all checks before pushing
+just check-all
+```
+
+See [`just --list`](justfile) for all available development commands.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-02-01
+
+### Changed
+
+- Updated `from_slice` feature for compatibility with Rust nightly (post-2026-01-28)
+  - Removed obsolete `LaneCount` and `SupportedLaneCount` trait bounds from SIMD code
+  - Lane count constraints now compiler-enforced (max 64 lanes, power-of-two only)
+  - Requires recent Rust nightly for `from_slice` feature
+  - No functional changes; purely a compatibility update
+
 ## [0.4.1] - 2025-10-26
 
 - Implemented `RangeOnce<T>`, a zero-allocation adapter that yields **0 or 1**

--- a/examples/simd/is_consecutive1/src/lib.rs
+++ b/examples/simd/is_consecutive1/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::{
     ops::Sub,
-    simd::{prelude::*, LaneCount, SimdElement, SupportedLaneCount},
+    simd::{prelude::*, SimdElement},
 };
 
 // We can make our main function generic both for type and # of lanes:
@@ -14,7 +14,6 @@ pub fn is_consecutive_splat1_gen<T, const N: usize>(
 where
     T: SimdElement + PartialEq,
     Simd<T, N>: Sub<Simd<T, N>, Output = Simd<T, N>>,
-    LaneCount<N>: SupportedLaneCount,
 {
     let subtracted = chunk - comparison_value;
     Simd::splat(chunk[0]) == subtracted
@@ -46,7 +45,6 @@ macro_rules! define_is_consecutive_splat1 {
         #[inline]
         pub fn $function<const N: usize>(chunk: Simd<$type, N>) -> bool
         where
-            LaneCount<N>: SupportedLaneCount,
         {
             define_comparison_value_splat!(comparison_value_splat, $type);
 
@@ -59,8 +57,6 @@ macro_rules! define_is_consecutive_splat1 {
 macro_rules! define_comparison_value_splat {
     ($function:ident, $type:ty) => {
         pub const fn $function<const N: usize>() -> Simd<$type, N>
-        where
-            LaneCount<N>: SupportedLaneCount,
         {
             let mut arr: [$type; N] = [0; N];
             let mut i = 0;
@@ -101,8 +97,7 @@ pub trait IsConsecutive {
     fn is_consecutive<const N: usize>(chunk: Simd<Self, N>) -> bool
     where
         Self: SimdElement,
-        Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>,
-        LaneCount<N>: SupportedLaneCount;
+        Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>;
 }
 
 macro_rules! impl_is_consecutive {
@@ -113,7 +108,6 @@ macro_rules! impl_is_consecutive {
             where
                 Self: SimdElement,
                 Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>,
-                LaneCount<N>: SupportedLaneCount,
             {
                 define_is_consecutive_splat1!(is_consecutive_splat1, $type);
                 is_consecutive_splat1(chunk)

--- a/examples/simd/is_consecutive2/src/lib.rs
+++ b/examples/simd/is_consecutive2/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{
     ops::Add,
     ops::Sub,
-    simd::{prelude::*, LaneCount, SimdElement, SupportedLaneCount},
+    simd::{prelude::*, SimdElement},
 };
 
 #[macro_export]
@@ -12,7 +12,6 @@ macro_rules! define_is_consecutive_regular {
         #[inline]
         pub fn $function<const N: usize>(chunk: &[$type; N]) -> bool
         where
-            LaneCount<N>: SupportedLaneCount,
         {
             for i in 1..N {
                 if chunk[i - 1].checked_add(1) != Some(chunk[i]) {
@@ -32,7 +31,6 @@ macro_rules! define_is_consecutive_splat0 {
         where
             $type: SimdElement,
             Simd<$type, N>: Add<Simd<$type, N>, Output = Simd<$type, N>>,
-            LaneCount<N>: SupportedLaneCount,
         {
             define_comparison_value_splat0!(comparison_value_splat0, $type);
 
@@ -48,8 +46,6 @@ macro_rules! define_is_consecutive_splat0 {
 macro_rules! define_comparison_value_splat0 {
     ($function:ident, $type:ty) => {
         pub const fn $function<const N: usize>() -> Simd<$type, N>
-        where
-            LaneCount<N>: SupportedLaneCount,
         {
             let mut arr: [$type; N] = [0; N];
             let mut i = 0;
@@ -67,8 +63,6 @@ macro_rules! define_is_consecutive_splat1 {
     ($function:ident, $type:ty) => {
         #[inline]
         pub fn $function<const N: usize>(chunk: Simd<$type, N>) -> bool
-        where
-            LaneCount<N>: SupportedLaneCount,
         {
             define_comparison_value_splat!(comparison_value_splat, $type);
 
@@ -82,8 +76,6 @@ macro_rules! define_is_consecutive_splat1 {
 macro_rules! define_comparison_value_splat {
     ($function:ident, $type:ty) => {
         pub const fn $function<const N: usize>() -> Simd<$type, N>
-        where
-            LaneCount<N>: SupportedLaneCount,
         {
             let mut arr: [$type; N] = [0; N];
             let mut i = 0;
@@ -101,8 +93,6 @@ macro_rules! define_is_consecutive_splat2 {
     ($function:ident, $type:ty) => {
         #[inline]
         pub fn $function<const N: usize>(chunk: Simd<$type, N>) -> bool
-        where
-            LaneCount<N>: SupportedLaneCount,
         {
             define_comparison_value_splat!(comparison_value_splat, $type);
 
@@ -133,7 +123,6 @@ macro_rules! define_is_consecutive_rotate {
         pub fn $function<const N: usize>(chunk: Simd<$type, N>) -> bool
         where
             $type: SimdElement,
-            LaneCount<N>: SupportedLaneCount,
         {
             define_comparison_value_rotate!(comparison_value, $type);
 
@@ -150,7 +139,6 @@ macro_rules! define_comparison_value_rotate {
         pub const fn $function<const N: usize>() -> Simd<$type, N>
         where
             $type: SimdElement,
-            LaneCount<N>: SupportedLaneCount,
         {
             let mut arr: [$type; N] = [1; N];
             arr[0] = (1 as $type).wrapping_sub(N as $type);
@@ -192,28 +180,23 @@ fn test_is_consecutive() {
 pub trait IsConsecutive {
     fn is_consecutive_regular<const N: usize>(chunk: &[Self; N]) -> bool
     where
-        Self: Sized,
-        LaneCount<N>: SupportedLaneCount;
+        Self: Sized;
 
     fn is_consecutive_splat0<const N: usize>(chunk: Simd<Self, N>) -> bool
     where
-        Self: SimdElement,
-        LaneCount<N>: SupportedLaneCount;
+        Self: SimdElement;
 
     fn is_consecutive_splat1<const N: usize>(chunk: Simd<Self, N>) -> bool
     where
-        Self: SimdElement,
-        LaneCount<N>: SupportedLaneCount;
+        Self: SimdElement;
 
     fn is_consecutive_splat2<const N: usize>(chunk: Simd<Self, N>) -> bool
     where
-        Self: SimdElement,
-        LaneCount<N>: SupportedLaneCount;
+        Self: SimdElement;
 
     fn is_consecutive_rotate<const N: usize>(chunk: Simd<Self, N>) -> bool
     where
-        Self: SimdElement,
-        LaneCount<N>: SupportedLaneCount;
+        Self: SimdElement;
 }
 
 macro_rules! impl_is_consecutive {
@@ -221,8 +204,6 @@ macro_rules! impl_is_consecutive {
         impl IsConsecutive for $type {
             #[inline]
             fn is_consecutive_regular<const N: usize>(chunk: &[$type; N]) -> bool
-            where
-                LaneCount<N>: SupportedLaneCount,
             {
                 define_is_consecutive_regular!(is_consecutive_regular, $type);
                 is_consecutive_regular(chunk)
@@ -233,7 +214,6 @@ macro_rules! impl_is_consecutive {
             where
                 Self: SimdElement,
                 Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>,
-                LaneCount<N>: SupportedLaneCount,
             {
                 define_is_consecutive_splat0!(is_consecutive_splat0, $type);
                 is_consecutive_splat0(chunk)
@@ -244,7 +224,6 @@ macro_rules! impl_is_consecutive {
             where
                 Self: SimdElement,
                 Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>,
-                LaneCount<N>: SupportedLaneCount,
             {
                 define_is_consecutive_splat1!(is_consecutive_splat1, $type);
                 is_consecutive_splat1(chunk)
@@ -255,7 +234,6 @@ macro_rules! impl_is_consecutive {
             where
                 Self: SimdElement,
                 Simd<Self, N>: Add<Simd<Self, N>, Output = Simd<Self, N>>,
-                LaneCount<N>: SupportedLaneCount,
             {
                 define_is_consecutive_splat2!(is_consecutive_splat2, $type);
                 is_consecutive_splat2(chunk)
@@ -266,7 +244,6 @@ macro_rules! impl_is_consecutive {
             where
                 Self: SimdElement,
                 Simd<Self, N>: Add<Simd<Self, N>, Output = Simd<Self, N>>,
-                LaneCount<N>: SupportedLaneCount,
             {
                 define_is_consecutive_rotate!(is_consecutive_rotate, $type);
                 is_consecutive_rotate(chunk)

--- a/examples/simd/rust_simd_cheatsheet.md
+++ b/examples/simd/rust_simd_cheatsheet.md
@@ -46,7 +46,7 @@ which elements of the first are greater than those of the second. Also, supporte
 ## All about lanes
 
 - [`Simd::LANES`](https://doc.rust-lang.org/nightly/core/simd/struct.Simd.html#associatedconstant.LANES) - a constant indicating the number of elements (lanes) in a `Simd` struct.
-- [`SupportedLaneCount`](https://doc.rust-lang.org/nightly/core/simd/trait.SupportedLaneCount.html) - tells the allowed values of LANES. Use by generics.
+- Lane counts are now compiler-enforced with a maximum of 64 lanes. Previously constrained by `SupportedLaneCount` trait (removed in nightly as of Jan 2026).
 - [`simd.lanes`](https://doc.rust-lang.org/core/simd/struct.Simd.html#method.lanes) - const method that tells a Simd struct's number of lanes.
 
 ## Low-Level Alignment, Offsets etc

--- a/justfile
+++ b/justfile
@@ -1,0 +1,101 @@
+# Just commands for local CI testing
+# Install just: cargo install just
+# Run: just --list (to see all commands)
+# Run: just check-all (recommended before pushing)
+
+# ============================================================================
+# Main Commands (use these most often)
+# ============================================================================
+
+# Check everything locally before pushing (recommended!)
+check-all: clippy test-stable test-nightly fmt-check
+
+# Run all stable CI checks locally
+ci: clippy test-stable
+
+# Run all nightly CI checks locally
+ci-nightly: test-nightly
+
+# ============================================================================
+# Individual Check Commands
+# ============================================================================
+
+# Run clippy with CI settings (matches CI exactly)
+clippy:
+    cargo clippy --verbose --all-targets --features "std rog_experimental" -- -D clippy::all -A deprecated
+
+# Run all stable tests (matches CI)
+test-stable:
+    cargo test --verbose
+    cargo test --verbose --release
+    cargo test --verbose --no-default-features --features "rog_experimental"
+
+# Run nightly tests with from_slice feature
+test-nightly:
+    rustup override set nightly
+    cargo test --verbose --features "rog_experimental from_slice"
+    cargo test --verbose --all-features
+    rustup override set stable
+
+# Quick check before commit (clippy + basic tests)
+pre-commit: clippy
+    cargo test --verbose
+
+# ============================================================================
+# Quality & Publishing Checks
+# ============================================================================
+
+# Check documentation for dead links (requires cargo-deadlinks)
+doc-links:
+    cargo install cargo-deadlinks
+    cargo doc --no-deps --all-features
+    cargo deadlinks --dir target/doc | grep -vE '(help\.html|settings\.html)'
+
+# Audit dependencies for security and license issues (requires cargo-audit and cargo-deny)
+audit:
+    cargo install cargo-audit cargo-deny
+    cargo audit
+    cargo deny check
+
+# Test publishing without actually publishing
+publish-dry:
+    cargo publish --dry-run
+
+# Test publishing with all features
+publish-dry-all:
+    cargo publish --all-features --dry-run
+
+# Full local CI simulation (stable only, no WASM/embedded)
+ci-full: clippy test-stable doc-links audit publish-dry-all
+
+# ============================================================================
+# Utilities
+# ============================================================================
+
+# Clean build artifacts
+clean:
+    cargo clean
+
+# Format code
+fmt:
+    cargo fmt --all
+
+# Check formatting
+fmt-check:
+    cargo fmt --all -- --check
+
+# ============================================================================
+# SIMD Feature (from_slice) - Requires Nightly
+# ============================================================================
+
+# Build with from_slice feature
+build-simd:
+    rustup override set nightly
+    cargo build --features from_slice
+    rustup override set stable
+
+# Test with from_slice feature
+test-simd:
+    rustup override set nightly
+    cargo test --features from_slice
+    rustup override set stable

--- a/src/from_slice.rs
+++ b/src/from_slice.rs
@@ -120,8 +120,7 @@ macro_rules! define_const_reference {
         #[allow(clippy::cast_precision_loss)]
         #[allow(clippy::cast_possible_truncation)]
         #[allow(clippy::cast_possible_wrap)]
-        const fn comparison_value<const N: usize>() -> Simd<$type, N>
-        {
+        const fn comparison_value<const N: usize>() -> Simd<$type, N> {
             let mut arr: [$type; N] = [0; N];
             let mut i = 0;
             while i < N {

--- a/src/from_slice.rs
+++ b/src/from_slice.rs
@@ -2,7 +2,7 @@
 
 use crate::Integer;
 use alloc::slice;
-use core::simd::{LaneCount, Simd, SimdElement, SupportedLaneCount};
+use core::simd::{Simd, SimdElement};
 use core::{iter::FusedIterator, ops::RangeInclusive, ops::Sub};
 
 #[allow(clippy::redundant_pub_crate)]
@@ -12,7 +12,6 @@ use core::{iter::FusedIterator, ops::RangeInclusive, ops::Sub};
 pub(crate) struct FromSliceIter<'a, T, const N: usize>
 where
     T: SimdInteger,
-    LaneCount<N>: SupportedLaneCount,
 {
     prefix_iter: core::slice::Iter<'a, T>,
     previous_range: Option<RangeInclusive<T>>,
@@ -24,7 +23,6 @@ where
 impl<'a, T, const N: usize> FromSliceIter<'a, T, N>
 where
     T: SimdInteger,
-    LaneCount<N>: SupportedLaneCount,
 {
     pub(crate) fn new(slice: &'a [T]) -> Self {
         let (prefix, middle, suffix) = slice.as_simd();
@@ -43,7 +41,6 @@ impl<T, const N: usize> FusedIterator for FromSliceIter<'_, T, N>
 where
     T: SimdInteger,
     Simd<T, N>: Sub<Output = Simd<T, N>>,
-    LaneCount<N>: SupportedLaneCount,
 {
 }
 
@@ -51,7 +48,6 @@ impl<T, const N: usize> Iterator for FromSliceIter<'_, T, N>
 where
     T: SimdInteger,
     Simd<T, N>: Sub<Output = Simd<T, N>>,
-    LaneCount<N>: SupportedLaneCount,
 {
     type Item = RangeInclusive<T>;
 
@@ -116,8 +112,7 @@ where
 pub(crate) trait SimdInteger: Integer + SimdElement {
     fn is_consecutive<const N: usize>(chunk: Simd<Self, N>) -> bool
     where
-        Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>,
-        LaneCount<N>: SupportedLaneCount;
+        Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>;
 }
 
 macro_rules! define_const_reference {
@@ -126,8 +121,6 @@ macro_rules! define_const_reference {
         #[allow(clippy::cast_possible_truncation)]
         #[allow(clippy::cast_possible_wrap)]
         const fn comparison_value<const N: usize>() -> Simd<$type, N>
-        where
-            LaneCount<N>: SupportedLaneCount,
         {
             let mut arr: [$type; N] = [0; N];
             let mut i = 0;
@@ -150,7 +143,6 @@ macro_rules! impl_is_consecutive {
             where
                 Self: SimdElement,
                 Simd<Self, N>: Sub<Simd<Self, N>, Output = Simd<Self, N>>,
-                LaneCount<N>: SupportedLaneCount,
             {
                 define_const_reference!($type);
                 let subtracted = chunk - comparison_value();

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -864,12 +864,9 @@ impl Integer for char {
 
     #[inline]
     fn add_one(self) -> Self {
-        self.checked_add_one().map_or_else(
-            || {
-                panic!("char overflow"); // Panics in both debug and release modes
-            },
-            |next| next,
-        )
+        self.checked_add_one().unwrap_or_else(|| {
+            panic!("char overflow"); // Panics in both debug and release modes
+        })
     }
 
     #[inline]

--- a/src/merge_map.rs
+++ b/src/merge_map.rs
@@ -111,7 +111,7 @@ where
     {
         // Prioritize from right to left
         let iter = iter.into_iter().enumerate().map(|(i, x)| {
-            let priority_number =  i;
+            let priority_number = i;
             SetPriorityMap::new(x, priority_number)
         });
         // Merge RangeValues by start with ties broken by priority

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,10 +5,10 @@
 //! use range_set_blaze::prelude::*;
 //! ```
 pub use crate::{
-    intersection_dyn, intersection_map_dyn, symmetric_difference_dyn, symmetric_difference_map_dyn,
-    union_dyn, union_map_dyn, CheckSortedDisjoint, CheckSortedDisjointMap, DynSortedDisjoint,
-    DynSortedDisjointMap, IntoString, MultiwayRangeMapBlaze, MultiwayRangeMapBlazeRef,
-    MultiwayRangeSetBlaze, MultiwayRangeSetBlazeRef, MultiwaySortedDisjoint,
-    MultiwaySortedDisjointMap, RangeMapBlaze, RangeSetBlaze, SortedDisjoint, SortedDisjointMap,
-    SortedStarts, UIntPlusOne,
+    CheckSortedDisjoint, CheckSortedDisjointMap, DynSortedDisjoint, DynSortedDisjointMap,
+    IntoString, MultiwayRangeMapBlaze, MultiwayRangeMapBlazeRef, MultiwayRangeSetBlaze,
+    MultiwayRangeSetBlazeRef, MultiwaySortedDisjoint, MultiwaySortedDisjointMap, RangeMapBlaze,
+    RangeSetBlaze, SortedDisjoint, SortedDisjointMap, SortedStarts, UIntPlusOne, intersection_dyn,
+    intersection_map_dyn, symmetric_difference_dyn, symmetric_difference_map_dyn, union_dyn,
+    union_map_dyn,
 };

--- a/src/sorted_disjoint.rs
+++ b/src/sorted_disjoint.rs
@@ -77,10 +77,10 @@ pub trait SortedStarts<T: Integer>: Iterator<Item = RangeInclusive<T>> + FusedIt
 ///
 /// | Set Operators                             | Operator    | Multiway (same type)                              | Multiway (different types)           |
 /// |------------------------------------|-------------|---------------------------------------------------|--------------------------------------|
-/// | [`union`]                      | [`a` &#124; `b`] | `[a, b, c].`[`union`][multiway_union]`() `        | [`union_dyn!`]`(a, b, c)`         |
-/// | [`intersection`]               | [`a & b`]     | `[a, b, c].`[`intersection`][multiway_intersection]`() ` | [`intersection_dyn!`]`(a, b, c)`|
+/// | [`union`]                      | [`a` &#124; `b`] | <code>[a, b, c].[union][multiway_union]() </code>        | <code>[union_dyn!](a, b, c)</code>         |
+/// | [`intersection`]               | [`a & b`]     | <code>[a, b, c].[intersection][multiway_intersection]() </code> | <code>[intersection_dyn!](a, b, c)</code>|
 /// | [`difference`]                 | [`a - b`]     | *n/a*                                             | *n/a*                                |
-/// | [`symmetric_difference`]       | [`a ^ b`]     | `[a, b, c].`[`symmetric_difference`][multiway_symmetric_difference]`() ` | [`symmetric_difference_dyn!`]`(a, b, c)` |
+/// | [`symmetric_difference`]       | [`a ^ b`]     | <code>[a, b, c].[symmetric_difference][multiway_symmetric_difference]() </code> | <code>[symmetric_difference_dyn!](a, b, c)</code> |
 /// | [`complement`]                 | [`!a`]        | *n/a*                                             | *n/a*                                |
 ///
 /// [`a` &#124; `b`]: trait.SortedDisjoint.html#method.union

--- a/src/sorted_disjoint_map.rs
+++ b/src/sorted_disjoint_map.rs
@@ -98,12 +98,12 @@ where
 ///
 /// | Set Operator               | Operator                      | Multiway (same type)                                      | Multiway (different types)                     |
 /// |----------------------------|-------------------------------|-----------------------------------------------------------|-----------------------------------------------|
-/// | [`union`]                  | [`a` &#124; `b`]              | `[a, b, c].`[`union`][multiway_union]`() `                | [`union_map_dyn!`](a, b, c)                    |
-/// | [`intersection`]           | [`a & b`]                     | `[a, b, c].`[`intersection`][multiway_intersection]`() `  | [`intersection_map_dyn!`](a, b, c)             |
+/// | [`union`]                  | [`a` &#124; `b`]              | <code>[a, b, c].[union][multiway_union]() </code>                | [`union_map_dyn!`](a, b, c)                    |
+/// | [`intersection`]           | [`a & b`]                     | <code>[a, b, c].[intersection][multiway_intersection]() </code>  | [`intersection_map_dyn!`](a, b, c)             |
 /// | `intersection`             | [`a.map_and_set_intersection(s)`] | *n/a*                                                     | *n/a*                                          |
 /// | [`difference`]             | [`a - b`]                     | *n/a*                                                     | *n/a*                                          |
 /// | `difference`               | [`a.map_and_set_difference(s)`] | *n/a*                                                     | *n/a*                                          |
-/// | [`symmetric_difference`]   | [`a ^ b`]                     | `[a, b, c].`[`symmetric_difference`][multiway_symmetric_difference]`() ` | [`symmetric_difference_map_dyn!`](a, b, c) |
+/// | [`symmetric_difference`]   | [`a ^ b`]                     | <code>[a, b, c].[symmetric_difference][multiway_symmetric_difference]() </code> | [`symmetric_difference_map_dyn!`](a, b, c) |
 /// | [`complement`] (to set)    | [`!a`]                        | *n/a*                                                     | *n/a*                                          |
 /// | `complement` (to map)      | [`a.complement_with(&value)`] | *n/a*                                                     | *n/a*                                          |
 ///

--- a/src/tests_map.rs
+++ b/src/tests_map.rs
@@ -22,8 +22,6 @@ use core::{
     prelude::v1::*,
 };
 use itertools::Itertools;
-#[cfg(not(target_arch = "wasm32"))]
-use std::format;
 
 use wasm_bindgen_test::*;
 wasm_bindgen_test_configure!(run_in_browser);

--- a/tests/fonts_wasm.rs
+++ b/tests/fonts_wasm.rs
@@ -1,0 +1,2 @@
+//! Test module for WASM font support.
+


### PR DESCRIPTION
## Changes

- **SIMD compatibility**: Remove obsolete LaneCount/SupportedLaneCount (rust-lang/rust#151775)
- **Developer tooling**: Add justfile and CONTRIBUTING.md
- **Clippy fixes**: Address CI lint warnings

Closes #22 (if applicable)

## Testing
- [x] Local: `just check-all` passes
- [x] Dry-run: `just publish-dry-all` passes
- [ ] CI: Waiting for checks...