### PR TITLE
Accept generic std::ops::RangeBounds in insert operations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [target.wasm32-unknown-unknown]
 runner = "wasm-bindgen-test-runner"
 rustflags = ["--cfg=getrandom_backend=\"wasm_js\""]
+
+[alias]
+xtest = "nextest run -p range-set-blaze --all-targets"
+check-all = "run -p xtask -- check-all"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["docs/**/*"]
 [workspace]
 members = [
     ".",
+    "xtask",
     "tests/wasm-demo",
     "tests/wasm-led",
     "tests/embedded",

--- a/src/map.rs
+++ b/src/map.rs
@@ -1091,9 +1091,13 @@ impl<T: Integer, V: Eq + Clone> RangeMapBlaze<T, V> {
     /// assert_eq!(map.ranges_insert(3..=4, "c"), false);
     /// assert_eq!(map.len(), 5u64);
     /// ```
-    pub fn ranges_insert(&mut self, range: RangeInclusive<T>, value: V) -> bool {
+    pub fn ranges_insert<R>(&mut self, range: R, value: V) -> bool
+    where
+        R: RangeBounds<T>,
+    {
         let len_before = self.len;
-        self.internal_add(range, value);
+        let (start, end) = extract_range(range);
+        self.internal_add(start..=end, value);
         self.len != len_before
     }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -2020,6 +2020,7 @@ impl<T: Integer> Eq for RangeSetBlaze<T> {}
 ///
 /// Empty ranges are allowed.
 #[allow(clippy::redundant_pub_crate)]
+#[inline]
 pub(crate) fn extract_range<T: Integer, R>(range: R) -> (T, T)
 where
     R: RangeBounds<T>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -823,9 +823,13 @@ impl<T: Integer> RangeSetBlaze<T> {
     /// assert_eq!(set.ranges_insert(3..=4), false);
     /// assert_eq!(set.len(), 5u64);
     /// ```
-    pub fn ranges_insert(&mut self, range: RangeInclusive<T>) -> bool {
+    pub fn ranges_insert<R>(&mut self, range: R) -> bool
+    where
+        R: RangeBounds<T>,
+    {
         let len_before = self.len;
-        self.internal_add(range);
+        let (start, end) = extract_range(range);
+        self.internal_add(start..=end);
         self.len != len_before
     }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,114 @@
+use std::env;
+use std::process::{Command, ExitCode, Stdio};
+
+fn run_step(name: &str, args: &[&str]) -> bool {
+    println!("\n==> {name}");
+    let status = Command::new("cargo")
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+
+    match status {
+        Ok(s) if s.success() => true,
+        Ok(s) => {
+            eprintln!("step failed: {name} (status: {s})");
+            false
+        }
+        Err(err) => {
+            eprintln!("step failed: {name} (error: {err})");
+            false
+        }
+    }
+}
+
+fn check_all() -> ExitCode {
+    // If nextest is unavailable, fall back to cargo test while preserving flow.
+    let has_nextest = Command::new("cargo")
+        .args(["nextest", "--version"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success());
+
+    let mut steps: Vec<(&str, Vec<&str>)> = vec![
+        (
+            "clippy (std + rog_experimental)",
+            vec![
+                "clippy",
+                "--all-targets",
+                "--features",
+                "std rog_experimental",
+                "--",
+                "-D",
+                "clippy::all",
+                "-A",
+                "deprecated",
+            ],
+        ),
+        ("test --release", vec!["test", "--release"]),
+        (
+            "test --no-default-features --features rog_experimental",
+            vec![
+                "test",
+                "--no-default-features",
+                "--features",
+                "rog_experimental",
+            ],
+        ),
+        (
+            "nightly test --features rog_experimental from_slice",
+            vec![
+                "+nightly",
+                "test",
+                "--features",
+                "rog_experimental from_slice",
+            ],
+        ),
+        (
+            "nightly test --all-features",
+            vec!["+nightly", "test", "--all-features"],
+        ),
+    ];
+
+    if has_nextest {
+        steps.insert(
+            1,
+            (
+                "nextest -p range-set-blaze --all-targets",
+                vec!["xtest"],
+            ),
+        );
+    } else {
+        eprintln!("note: cargo-nextest not found; using cargo test -p range-set-blaze --all-targets");
+        steps.insert(
+            1,
+            (
+                "test -p range-set-blaze --all-targets",
+                vec!["test", "-p", "range-set-blaze", "--all-targets"],
+            ),
+        );
+    }
+
+    for (name, args) in steps {
+        if !run_step(name, &args) {
+            eprintln!("\ncheck-all FAILED");
+            return ExitCode::from(1);
+        }
+    }
+
+    println!("\ncheck-all PASSED");
+    ExitCode::SUCCESS
+}
+
+fn main() -> ExitCode {
+    let mut args = env::args().skip(1);
+    match args.next().as_deref() {
+        Some("check-all") => check_all(),
+        _ => {
+            eprintln!("usage: cargo check-all");
+            ExitCode::from(2)
+        }
+    }
+}


### PR DESCRIPTION
Have the basic `RangeSetBlaze::ranges_insert` and `RangeMapBlaze::ranges_insert` methods accept any generic `RangeBounds`, rather than exclusively accepting `RangeInclusive`.

Note that it does not seem possible to implement this for the constructor `From<RangeInclusive<T>> for RangeSetBlaze<T>` as the compiler says there may be conflicting trait implementations, if a downstream crate implements `RangeBounds` on `RangeSetBlaze` (conflicting with the libcore blanket `impl From<T> for T`).

Currently does not change any constructor/insertion methods that take iterators of ranges, nor any getters.

Closes #24