### PR TITLE
Remove unused Trait bounds on structs 

### DIFF
--- a/src/intersection_iter_map.rs
+++ b/src/intersection_iter_map.rs
@@ -15,13 +15,7 @@ use crate::{SortedDisjoint, SortedDisjointMap, map::ValueRef};
 /// [`map_and_set_intersection`]: crate::SortedDisjointMap::map_and_set_intersection
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub struct IntersectionIterMap<T, VR, IM, IS>
-where
-    T: Integer,
-    VR: ValueRef,
-    IM: SortedDisjointMap<T, VR>,
-    IS: SortedDisjoint<T>,
-{
+pub struct IntersectionIterMap<T, VR, IM, IS> {
     iter_left: IM,
     iter_right: IS,
     right: Option<RangeInclusive<T>>,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,12 +4,12 @@ use core::hash::BuildHasher;
 use core::ops::RangeBounds;
 use std::collections::BTreeSet;
 
-pub struct RangeSet<T, B: BuildHasher> {
+pub struct RangeSet<T, B> {
     set: BTreeSet<T>,
     hasher: B,
 }
 
-pub struct RangeSetIter<'a, T: Copy + Ord, B: BuildHasher> {
+pub struct RangeSetIter<'a, T, B> {
     inner: std::collections::btree_set::Iter<'a, T>,
     hasher: &'a B,
 }

--- a/src/iter_map.rs
+++ b/src/iter_map.rs
@@ -16,12 +16,7 @@ use crate::{
 /// [`iter`]: crate::RangeMapBlaze::iter
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub struct IterMap<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
-{
+pub struct IterMap<T, VR, I> {
     iter: I,
     option_range_value_front: Option<(RangeInclusive<T>, VR)>,
     option_range_value_back: Option<(RangeInclusive<T>, VR)>,
@@ -116,11 +111,7 @@ where
 /// [`into_iter`]: crate::RangeMapBlaze::into_iter
 #[derive(Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct IntoIterMap<T, V>
-where
-    T: Integer,
-    V: Eq + Clone,
-{
+pub struct IntoIterMap<T, V> {
     option_start_end_value_front: Option<(T, EndValue<T, V>)>,
     option_start_end_value_back: Option<(T, EndValue<T, V>)>,
     into_iter: btree_map::IntoIter<T, EndValue<T, V>>,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -16,12 +16,7 @@ use crate::{
 /// [`RangeMapBlaze`]: crate::RangeMapBlaze
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub struct Keys<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
-{
+pub struct Keys<T, VR, I> {
     iter: IterMap<T, VR, I>,
 }
 
@@ -83,11 +78,7 @@ where
 /// [`RangeMapBlaze`]: crate::RangeMapBlaze
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
-pub struct IntoKeys<T, V>
-where
-    T: Integer,
-    V: Eq + Clone,
-{
+pub struct IntoKeys<T, V> {
     into_iter: IntoIterMap<T, V>,
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -147,11 +147,7 @@ where
 
 #[expect(clippy::redundant_pub_crate)]
 #[derive(Clone, Hash, Default, PartialEq, Eq, Debug)]
-pub(crate) struct EndValue<T, V>
-where
-    T: Integer,
-    V: Eq + Clone,
-{
+pub(crate) struct EndValue<T, V> {
     pub(crate) end: T,
     pub(crate) value: V,
 }
@@ -446,7 +442,7 @@ where
 ///
 /// [module-level documentation]: index.html
 #[derive(Clone, Hash, PartialEq)]
-pub struct RangeMapBlaze<T: Integer, V: Eq + Clone> {
+pub struct RangeMapBlaze<T: Integer, V> {
     pub(crate) len: <T as Integer>::SafeLen,
     pub(crate) btree_map: BTreeMap<T, EndValue<T, V>>,
 }
@@ -2234,7 +2230,7 @@ impl<'a, T: Integer, V: Eq + Clone> IntoIterator for &'a RangeMapBlaze<T, V> {
 
 impl<T: Integer, V: Eq + Clone> BitOr<Self> for RangeMapBlaze<T, V> {
     /// Unions the contents of two [`RangeMapBlaze`]'s.
-    ///  
+    ///
     /// This operator has *right precedence*: when overlapping ranges are present,
     /// values on the right-hand side take priority over those self.
     ///

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,4 +1,4 @@
-use core::{iter::FusedIterator, ops::RangeInclusive};
+use core::{fmt::Debug, iter::FusedIterator, ops::RangeInclusive};
 
 use itertools::{Itertools, KMergeBy, MergeBy};
 
@@ -9,9 +9,8 @@ use crate::{Integer, SortedDisjoint, SortedStarts};
 #[derive(Clone, Debug)]
 pub struct Merge<T, L, R>
 where
-    T: Integer,
-    L: SortedDisjoint<T>,
-    R: SortedDisjoint<T>,
+    L: Iterator<Item: Debug + Clone>,
+    R: Iterator<Item: Debug + Clone>,
 {
     #[allow(clippy::type_complexity)]
     iter: MergeBy<L, R, fn(&RangeInclusive<T>, &RangeInclusive<T>) -> bool>,
@@ -73,8 +72,7 @@ where
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct KMerge<T, I>
 where
-    T: Integer,
-    I: SortedDisjoint<T>,
+    I: Iterator<Item: Debug + Clone>,
 {
     #[allow(clippy::type_complexity)]
     iter: KMergeBy<I, fn(&RangeInclusive<T>, &RangeInclusive<T>) -> bool>,

--- a/src/merge_map.rs
+++ b/src/merge_map.rs
@@ -1,4 +1,5 @@
 use core::iter::FusedIterator;
+use core::ops::RangeInclusive;
 
 use itertools::{Itertools, KMergeBy, MergeBy};
 
@@ -11,13 +12,12 @@ use crate::sorted_disjoint_map::{Priority, PrioritySortedStartsMap, SortedDisjoi
 /// Used internally by `UnionIterMap` and `SymDiffIterMap`.
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct MergeMap<T, VR, L, R>
-where
-    T: Integer,
-    VR: ValueRef,
-    L: SortedDisjointMap<T, VR>,
-    R: SortedDisjointMap<T, VR>,
-{
+pub struct MergeMap<
+    T,
+    VR,
+    L: Iterator<Item = (RangeInclusive<T>, VR)>,
+    R: Iterator<Item = (RangeInclusive<T>, VR)>,
+> {
     #[allow(clippy::type_complexity)]
     iter: MergeBy<
         SetPriorityMap<T, VR, L>,
@@ -85,9 +85,7 @@ where
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct KMergeMap<T, VR, I>
 where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
+    I: Iterator<Item = (RangeInclusive<T>, VR)>,
 {
     #[allow(clippy::type_complexity)]
     iter: KMergeBy<SetPriorityMap<T, VR, I>, fn(&Priority<T, VR>, &Priority<T, VR>) -> bool>,

--- a/src/not_iter.rs
+++ b/src/not_iter.rs
@@ -7,11 +7,7 @@ use crate::{Integer, SortedDisjoint};
 /// [`SortedDisjointMap::complement_with`]: trait.SortedDisjointMap.html#method.complement_with
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct NotIter<T, I>
-where
-    T: Integer,
-    I: SortedDisjoint<T>,
-{
+pub struct NotIter<T, I> {
     iter: I,
     start_not: T,
     next_time_return_none: bool,

--- a/src/range_values.rs
+++ b/src/range_values.rs
@@ -16,7 +16,7 @@ use crate::{map::EndValue, sorted_disjoint_map::SortedDisjointMap};
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[allow(clippy::module_name_repetitions)]
-pub struct RangeValuesIter<'a, T: Integer, V: Eq + Clone> {
+pub struct RangeValuesIter<'a, T, V> {
     iter: btree_map::Iter<'a, T, EndValue<T, V>>,
 }
 
@@ -75,7 +75,7 @@ where
 /// [`into_range_values`]: crate::RangeMapBlaze::into_range_values
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
-pub struct IntoRangeValuesIter<T: Integer, V: Eq + Clone> {
+pub struct IntoRangeValuesIter<T, V> {
     iter: btree_map::IntoIter<T, EndValue<T, V>>,
 }
 
@@ -129,7 +129,7 @@ impl<T: Integer, V: Eq + Clone> DoubleEndedIterator for IntoRangeValuesIter<T, V
 /// [`ranges`]: crate::RangeMapBlaze::ranges
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct MapRangesIter<'a, T: Integer, V: Eq + Clone> {
+pub struct MapRangesIter<'a, T, V> {
     iter: btree_map::Iter<'a, T, EndValue<T, V>>,
     gather: Option<RangeInclusive<T>>,
 }
@@ -193,7 +193,7 @@ where
 /// [`into_ranges`]: crate::RangeMapBlaze::into_ranges
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
-pub struct MapIntoRangesIter<T: Integer, V: Eq + Clone> {
+pub struct MapIntoRangesIter<T, V> {
     iter: btree_map::IntoIter<T, EndValue<T, V>>,
     gather: Option<RangeInclusive<T>>,
 }
@@ -249,12 +249,7 @@ impl<T: Integer, V: Eq + Clone> Iterator for MapIntoRangesIter<T, V> {
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[allow(clippy::module_name_repetitions)]
-pub struct RangeValuesToRangesIter<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
-{
+pub struct RangeValuesToRangesIter<T, VR, I> {
     iter: I,
     gather: Option<RangeInclusive<T>>,
     phantom: PhantomData<VR>,
@@ -343,12 +338,7 @@ impl<T> ExpectDebugUnwrapRelease<T> for Option<T> {
 #[expect(clippy::redundant_pub_crate)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub(crate) struct SetPriorityMap<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
-{
+pub(crate) struct SetPriorityMap<T, VR, I> {
     iter: I,
     priority_number: usize,
     phantom: PhantomData<(T, VR)>,
@@ -362,12 +352,7 @@ where
 {
 }
 
-impl<T, VR, I> Iterator for SetPriorityMap<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
-{
+impl<T, VR, I: Iterator<Item = (RangeInclusive<T>, VR)>> Iterator for SetPriorityMap<T, VR, I> {
     type Item = Priority<T, VR>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
-pub struct Ranges<'a, T: 'a + Copy + Ord, B: BuildHasher> {
+pub struct Ranges<'a, T, B> {
     map: &'a HashMap<T, BTreeSet<T>, B>,
     iter: Option<btree_set::Iter<'a, T>>,
     range: Option<(&'a T, &'a T)>,

--- a/src/ranges_iter.rs
+++ b/src/ranges_iter.rs
@@ -9,7 +9,7 @@ use core::{iter::FusedIterator, ops::RangeInclusive};
 /// [`ranges`]: crate::RangeSetBlaze::ranges
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct RangesIter<'a, T: Integer> {
+pub struct RangesIter<'a, T> {
     pub(crate) iter: btree_map::Iter<'a, T, T>,
 }
 
@@ -47,7 +47,7 @@ impl<T: Integer> DoubleEndedIterator for RangesIter<'_, T> {
 /// [`into_ranges`]: crate::RangeSetBlaze::into_ranges
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
-pub struct IntoRangesIter<T: Integer> {
+pub struct IntoRangesIter<T> {
     pub(crate) iter: alloc::collections::btree_map::IntoIter<T, T>,
 }
 

--- a/src/rog.rs
+++ b/src/rog.rs
@@ -18,7 +18,7 @@ use crate::{Integer, RangeSetBlaze, set::extract_range};
 /// [`RangeSetBlaze`]: crate::RangeSetBlaze
 /// [`rogs_range`]: crate::RangeSetBlaze::rogs_range
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct RogsIter<'a, T: Integer> {
+pub struct RogsIter<'a, T> {
     end_in: T,
     next_rog: Option<Rog<T>>,
     final_gap_start: Option<T>,
@@ -88,7 +88,7 @@ impl<T: Integer> FusedIterator for RogsIter<'_, T> {}
 /// ```
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum Rog<T: Integer> {
+pub enum Rog<T> {
     /// A range of integers in a [`RangeSetBlaze`].
     Range(RangeInclusive<T>),
     /// A gap between integers in a [`RangeSetBlaze`].

--- a/src/set.rs
+++ b/src/set.rs
@@ -1563,11 +1563,7 @@ impl<T: Integer> IntoIterator for RangeSetBlaze<T> {
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 #[allow(clippy::struct_field_names)]
-pub struct Iter<T, I>
-where
-    T: Integer,
-    I: SortedDisjoint<T>,
-{
+pub struct Iter<T, I> {
     btree_set_iter: I,
     // FUTURE: here and elsewhere, when core::iter:Step is available could
     // FUTURE: use RangeInclusive as an iterator (with exhaustion) rather than needing an Option
@@ -1640,7 +1636,7 @@ where
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 #[allow(clippy::struct_field_names)]
-pub struct IntoIter<T: Integer> {
+pub struct IntoIter<T> {
     option_range_front: Option<RangeInclusive<T>>,
     option_range_back: Option<RangeInclusive<T>>,
     btree_map_into_iter: btree_map::IntoIter<T, T>,

--- a/src/sorted_disjoint.rs
+++ b/src/sorted_disjoint.rs
@@ -594,11 +594,7 @@ pub trait SortedDisjoint<T: Integer>: SortedStarts<T> {
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[allow(clippy::module_name_repetitions)]
-pub struct CheckSortedDisjoint<T, I>
-where
-    T: Integer,
-    I: Iterator<Item = RangeInclusive<T>> + FusedIterator,
-{
+pub struct CheckSortedDisjoint<T, I> {
     pub(crate) iter: I,
     prev_end: Option<T>,
     seen_none: bool,
@@ -620,10 +616,7 @@ where
     }
 }
 
-impl<T> Default for CheckSortedDisjoint<T, array::IntoIter<RangeInclusive<T>, 0>>
-where
-    T: Integer,
-{
+impl<T: Integer> Default for CheckSortedDisjoint<T, array::IntoIter<RangeInclusive<T>, 0>> {
     // Default is an empty iterator.
     fn default() -> Self {
         Self::new([])

--- a/src/sorted_disjoint_map.rs
+++ b/src/sorted_disjoint_map.rs
@@ -629,12 +629,7 @@ where
 #[allow(clippy::module_name_repetitions)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct CheckSortedDisjointMap<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: Iterator<Item = (RangeInclusive<T>, VR)>,
-{
+pub struct CheckSortedDisjointMap<T, VR, I> {
     iter: I,
     seen_none: bool,
     previous: Option<(RangeInclusive<T>, VR)>,
@@ -749,20 +744,12 @@ where
 
 /// Used internally by `MergeMap`.
 #[derive(Clone, Debug)]
-pub struct Priority<T, VR>
-where
-    T: Integer,
-    VR: ValueRef,
-{
+pub struct Priority<T, VR> {
     range_value: (RangeInclusive<T>, VR),
     priority_number: usize,
 }
 
-impl<T, VR> Priority<T, VR>
-where
-    T: Integer,
-    VR: ValueRef,
-{
+impl<T, VR> Priority<T, VR> {
     pub(crate) const fn new(range_value: (RangeInclusive<T>, VR), priority_number: usize) -> Self {
         Self {
             range_value,
@@ -861,12 +848,7 @@ where
 /// Used internally by `complement_with`.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub struct RangeToRangeValueIter<'a, T, V, I>
-where
-    T: Integer,
-    V: Eq + Clone,
-    I: SortedDisjoint<T>,
-{
+pub struct RangeToRangeValueIter<'a, T, V, I> {
     inner: I,
     value: &'a V,
     phantom: PhantomData<T>,

--- a/src/sym_diff_iter.rs
+++ b/src/sym_diff_iter.rs
@@ -12,11 +12,7 @@ use core::{cmp::Reverse, iter::FusedIterator, ops::RangeInclusive};
 /// [`symmetric_difference`]: crate::SortedDisjointMap::symmetric_difference
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct SymDiffIter<T, I>
-where
-    T: Integer,
-    I: SortedStarts<T>,
-{
+pub struct SymDiffIter<T, I> {
     iter: I,
     start_or_min_value: T,
     end_heap: BinaryHeap<Reverse<T>>,

--- a/src/sym_diff_iter_map.rs
+++ b/src/sym_diff_iter_map.rs
@@ -20,12 +20,7 @@ use crate::{
 /// [`symmetric_difference`]: crate::SortedDisjointMap::symmetric_difference
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct SymDiffIterMap<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: PrioritySortedStartsMap<T, VR>,
-{
+pub struct SymDiffIterMap<T, VR, I> {
     iter: I,
     next_item: Option<Priority<T, VR>>,
     workspace: BinaryHeap<Priority<T, VR>>,
@@ -35,10 +30,7 @@ where
 }
 
 #[expect(clippy::ref_option)]
-fn min_next_end<T>(next_end: &Option<T>, next_item_end: T) -> T
-where
-    T: Integer,
-{
+fn min_next_end<T: Integer>(next_end: &Option<T>, next_item_end: T) -> T {
     next_end.map_or_else(
         || next_item_end,
         |current_end| cmp::min(current_end, next_item_end),

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -42,7 +42,7 @@ pub fn width_to_range_u32(
 // Not reliable if the range is too small, especially if the range_len
 // is small. Might have some off-by-one errors that aren't material in practice.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct MemorylessRange<'a, T: Integer + SampleUniform> {
+pub struct MemorylessRange<'a, T> {
     rng: &'a mut StdRng,
     range_len: usize,
     range: RangeInclusive<T>,
@@ -148,7 +148,7 @@ impl<T: Integer + SampleUniform> Iterator for MemorylessRange<'_, T> {
 }
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct MemorylessIter<'a, T: Integer + SampleUniform> {
+pub struct MemorylessIter<'a, T> {
     option_range: Option<RangeInclusive<T>>,
     iter: MemorylessRange<'a, T>,
 }
@@ -188,7 +188,7 @@ impl<T: Integer + SampleUniform> Iterator for MemorylessIter<'_, T> {
 }
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct ClumpyMapIter<'a, T: Integer + SampleUniform> {
+pub struct ClumpyMapIter<'a, T> {
     iter: ClumpyMapRange<'a, T>,
     option_range_value: Option<(RangeInclusive<T>, u32)>,
 }
@@ -243,7 +243,7 @@ impl<T: Integer + SampleUniform> Iterator for ClumpyMapIter<'_, T> {
 }
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct ClumpyMapRange<'a, T: Integer + SampleUniform> {
+pub struct ClumpyMapRange<'a, T> {
     rng_clone: StdRng,
     clump_iter: MemorylessRange<'a, T>,
     value_count: u32,

--- a/src/tests_map.rs
+++ b/src/tests_map.rs
@@ -238,7 +238,7 @@ const fn check_traits() {
     is_like_btreemap_iter_less_both::<AMergeMap<'_>>();
 
     type AAssumePrioritySortedStartsMap<'a> =
-        AssumePrioritySortedStartsMap<i32, &'a u64, vec::IntoIter<Priority<i32, &'a u64>>>;
+        AssumePrioritySortedStartsMap<vec::IntoIter<Priority<i32, &'a u64>>>;
     is_sssu::<AAssumePrioritySortedStartsMap<'_>>();
     is_like_btreemap_iter_less_both::<AAssumePrioritySortedStartsMap<'_>>();
 

--- a/src/union_iter.rs
+++ b/src/union_iter.rs
@@ -15,11 +15,7 @@ use itertools::Itertools;
 /// [`union`]: crate::SortedDisjoint::union
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct UnionIter<T, SS>
-where
-    T: Integer,
-    SS: SortedStarts<T>,
-{
+pub struct UnionIter<T, SS> {
     iter: SS,
     option_range: Option<RangeInclusive<T>>,
 }
@@ -103,10 +99,7 @@ where
 }
 
 // from iter (T, VR) to UnionIter
-impl<T> FromIterator<RangeInclusive<T>> for UnionIter<T, SortedStartsInVec<T>>
-where
-    T: Integer,
-{
+impl<T: Integer> FromIterator<RangeInclusive<T>> for UnionIter<T, SortedStartsInVec<T>> {
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = RangeInclusive<T>>,

--- a/src/union_iter_map.rs
+++ b/src/union_iter_map.rs
@@ -12,10 +12,9 @@ use crate::Integer;
 use crate::unsorted_priority_map::AssumePrioritySortedStartsMap;
 use crate::unsorted_priority_map::UnsortedPriorityMap;
 
-type SortedStartsInVecMap<T, VR> =
-    AssumePrioritySortedStartsMap<T, VR, vec::IntoIter<Priority<T, VR>>>;
+type SortedStartsInVecMap<T, VR> = AssumePrioritySortedStartsMap<vec::IntoIter<Priority<T, VR>>>;
 #[allow(clippy::redundant_pub_crate)]
-pub(crate) type SortedStartsInVec<T> = AssumeSortedStarts<T, vec::IntoIter<RangeInclusive<T>>>;
+pub(crate) type SortedStartsInVec<T> = AssumeSortedStarts<vec::IntoIter<RangeInclusive<T>>>;
 
 /// This `struct` is created by the [`union`] method. See [`union`]'s
 /// documentation for more.
@@ -23,12 +22,7 @@ pub(crate) type SortedStartsInVec<T> = AssumeSortedStarts<T, vec::IntoIter<Range
 /// [`union`]: crate::SortedDisjointMap::union
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct UnionIterMap<T, VR, SS>
-where
-    T: Integer,
-    VR: ValueRef,
-    SS: PrioritySortedStartsMap<T, VR>,
-{
+pub struct UnionIterMap<T, VR, SS> {
     iter: SS,
     next_item: Option<Priority<T, VR>>,
     workspace: BinaryHeap<Priority<T, VR>>,

--- a/src/unsorted_disjoint.rs
+++ b/src/unsorted_disjoint.rs
@@ -8,11 +8,7 @@ use num_traits::Zero;
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[allow(clippy::redundant_pub_crate)]
-pub(crate) struct UnsortedDisjoint<T, I>
-where
-    T: Integer,
-    I: Iterator<Item = RangeInclusive<T>>,
-{
+pub(crate) struct UnsortedDisjoint<T, I> {
     iter: I,
     option_range: Option<RangeInclusive<T>>,
     min_value_plus_2: T,
@@ -90,11 +86,7 @@ where
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[allow(clippy::redundant_pub_crate)]
-pub(crate) struct SortedDisjointWithLenSoFar<T, I>
-where
-    T: Integer,
-    I: SortedDisjoint<T>,
-{
+pub(crate) struct SortedDisjointWithLenSoFar<T: Integer, I> {
     iter: I,
     len: <T as Integer>::SafeLen,
 }
@@ -151,27 +143,23 @@ where
 #[derive(Clone, Debug)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 /// Gives any iterator of ranges the [`SortedStarts`] trait without any checking.
-pub struct AssumeSortedStarts<T, I>
-where
-    T: Integer,
-    I: Iterator<Item = RangeInclusive<T>> + FusedIterator,
-{
+pub struct AssumeSortedStarts<I> {
     pub(crate) iter: I,
 }
 
-impl<T, I> FusedIterator for AssumeSortedStarts<T, I>
+impl<T, I> FusedIterator for AssumeSortedStarts<I>
 where
     T: Integer,
     I: Iterator<Item = RangeInclusive<T>> + FusedIterator,
 {
 }
 
-impl<T: Integer, I> SortedStarts<T> for AssumeSortedStarts<T, I> where
+impl<T: Integer, I> SortedStarts<T> for AssumeSortedStarts<I> where
     I: Iterator<Item = RangeInclusive<T>> + FusedIterator
 {
 }
 
-impl<T, I> AssumeSortedStarts<T, I>
+impl<T, I> AssumeSortedStarts<I>
 where
     T: Integer,
     I: Iterator<Item = RangeInclusive<T>> + FusedIterator,
@@ -185,7 +173,7 @@ where
     }
 }
 
-impl<T, I> Iterator for AssumeSortedStarts<T, I>
+impl<T, I> Iterator for AssumeSortedStarts<I>
 where
     T: Integer,
     I: Iterator<Item = RangeInclusive<T>> + FusedIterator,

--- a/src/unsorted_priority_map.rs
+++ b/src/unsorted_priority_map.rs
@@ -12,12 +12,7 @@ use num_traits::Zero;
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[allow(clippy::redundant_pub_crate)]
-pub(crate) struct UnsortedPriorityMap<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: Iterator<Item = (RangeInclusive<T>, VR)>,
-{
+pub(crate) struct UnsortedPriorityMap<T, VR, I> {
     iter: I,
     option_priority: Option<Priority<T, VR>>,
     min_value_plus_2: T,
@@ -117,12 +112,7 @@ where
 
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[allow(clippy::redundant_pub_crate)]
-pub(crate) struct SortedDisjointMapWithLenSoFar<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
-{
+pub(crate) struct SortedDisjointMapWithLenSoFar<T: Integer, VR, I> {
     iter: I,
     len: <T as Integer>::SafeLen,
     phantom: PhantomData<VR>,
@@ -188,16 +178,11 @@ where
 ///
 /// [`UnionIterMap`]: crate::UnionIterMap
 /// [`SymDiffIterMap`]: crate::SymDiffIterMap
-pub struct AssumePrioritySortedStartsMap<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: Iterator<Item = Priority<T, VR>> + FusedIterator,
-{
+pub struct AssumePrioritySortedStartsMap<I> {
     iter: I,
 }
 
-impl<T, VR, I> PrioritySortedStartsMap<T, VR> for AssumePrioritySortedStartsMap<T, VR, I>
+impl<T, VR, I> PrioritySortedStartsMap<T, VR> for AssumePrioritySortedStartsMap<I>
 where
     T: Integer,
     VR: ValueRef,
@@ -205,7 +190,7 @@ where
 {
 }
 
-impl<T, VR, I> AssumePrioritySortedStartsMap<T, VR, I>
+impl<T, VR, I> AssumePrioritySortedStartsMap<I>
 where
     T: Integer,
     VR: ValueRef,
@@ -216,7 +201,7 @@ where
     }
 }
 
-impl<T, VR, I> FusedIterator for AssumePrioritySortedStartsMap<T, VR, I>
+impl<T, VR, I> FusedIterator for AssumePrioritySortedStartsMap<I>
 where
     T: Integer,
     VR: ValueRef,
@@ -224,7 +209,7 @@ where
 {
 }
 
-impl<T, VR, I> Iterator for AssumePrioritySortedStartsMap<T, VR, I>
+impl<T, VR, I> Iterator for AssumePrioritySortedStartsMap<I>
 where
     T: Integer,
     VR: ValueRef,

--- a/src/values.rs
+++ b/src/values.rs
@@ -16,12 +16,7 @@ use crate::{
 /// [`RangeMapBlaze`]: crate::RangeMapBlaze
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub struct Values<T, VR, I>
-where
-    T: Integer,
-    VR: ValueRef,
-    I: SortedDisjointMap<T, VR>,
-{
+pub struct Values<T, VR, I> {
     iter: IterMap<T, VR, I>,
 }
 
@@ -83,11 +78,7 @@ where
 /// [`RangeMapBlaze`]: crate::RangeMapBlaze
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
-pub struct IntoValues<T, V>
-where
-    T: Integer,
-    V: Eq + Clone,
-{
+pub struct IntoValues<T, V> {
     into_iter: IntoIterMap<T, V>,
 }
 

--- a/tests/fonts_wasm.rs
+++ b/tests/fonts_wasm.rs
@@ -1,2 +1,1 @@
 //! Test module for WASM font support.
-

--- a/tests/set_tests.rs
+++ b/tests/set_tests.rs
@@ -3131,7 +3131,7 @@ const fn check_traits() {
     is_sssu::<ASymDiffIter<'_>>();
     is_like_btreeset_iter_less_both::<ASymDiffIter<'_>>();
 
-    type AAssumeSortedStarts<'a> = AssumeSortedStarts<i32, ARangesIter<'a>>;
+    type AAssumeSortedStarts<'a> = AssumeSortedStarts<ARangesIter<'a>>;
     is_sssu::<AAssumeSortedStarts<'_>>();
     is_like_btreeset_iter_less_both::<AAssumeSortedStarts<'_>>();
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -107,7 +107,9 @@ fn check_all() -> ExitCode {
             ),
         );
     } else {
-        eprintln!("note: cargo-nextest not found; using cargo test -p range-set-blaze --lib --tests --examples");
+        eprintln!(
+            "note: cargo-nextest not found; using cargo test -p range-set-blaze --lib --tests --examples"
+        );
         steps.insert(
             1,
             (
@@ -132,9 +134,11 @@ fn check_all() -> ExitCode {
         .map(|(idx, (name, args))| {
             let failures = Arc::clone(&failures);
             thread::spawn(move || {
-                let target_dir = PathBuf::from("target")
-                    .join("check-all")
-                    .join(format!("{:02}-{}", idx + 1, slugify(&name)));
+                let target_dir = PathBuf::from("target").join("check-all").join(format!(
+                    "{:02}-{}",
+                    idx + 1,
+                    slugify(&name)
+                ));
                 if !run_step(&name, &args, &target_dir) {
                     failures.lock().expect("poisoned mutex").push(name);
                 }


### PR DESCRIPTION
Removes not needed trait bounds from generics on structs. This removes unneded boilerplate and reflects the rust style of doing it (see e.g. `HashSet<T>`, which has no bound on `T: Hash`)  

BREAKING: AssumeSortedStarts and  AssumePrioritySortedStarts now have fewer generic arguments

`just check-all` run successfully 