### PR TITLE
Implement SortedStarts and SortedDisjoint for std::iter::* types

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,5 +218,4 @@ cargo install just
 just check-all
 ```
 
-See [`just --list`](justfile) for all available development commands.
-
+See `just --list` for all available development commands (defined in `justfile`).

--- a/src/sorted_disjoint.rs
+++ b/src/sorted_disjoint.rs
@@ -184,10 +184,10 @@ impl<T: Integer> SortedDisjoint<T> for core::iter::Once<core::ops::RangeInclusiv
 ///
 /// | Set Operators                             | Operator    | Multiway (same type)                              | Multiway (different types)           |
 /// |------------------------------------|-------------|---------------------------------------------------|--------------------------------------|
-/// | [`union`]                      | [`a` &#124; `b`] | <code>[a, b, c].[union][multiway_union]() </code>        | <code>[union_dyn!](a, b, c)</code>         |
-/// | [`intersection`]               | [`a & b`]     | <code>[a, b, c].[intersection][multiway_intersection]() </code> | <code>[intersection_dyn!](a, b, c)</code>|
+/// | [`union`]                      | [`a` &#124; `b`] | <code>[a, b, c].[union][multiway_union]() </code>        | <code>[union_dyn!][union_dyn_macro](a, b, c)</code>         |
+/// | [`intersection`]               | [`a & b`]     | <code>[a, b, c].[intersection][multiway_intersection]() </code> | <code>[intersection_dyn!][intersection_dyn_macro](a, b, c)</code>|
 /// | [`difference`]                 | [`a - b`]     | *n/a*                                             | *n/a*                                |
-/// | [`symmetric_difference`]       | [`a ^ b`]     | <code>[a, b, c].[symmetric_difference][multiway_symmetric_difference]() </code> | <code>[symmetric_difference_dyn!](a, b, c)</code> |
+/// | [`symmetric_difference`]       | [`a ^ b`]     | <code>[a, b, c].[symmetric_difference][multiway_symmetric_difference]() </code> | <code>[symmetric_difference_dyn!][symmetric_difference_dyn_macro](a, b, c)</code> |
 /// | [`complement`]                 | [`!a`]        | *n/a*                                             | *n/a*                                |
 ///
 /// [`a` &#124; `b`]: trait.SortedDisjoint.html#method.union
@@ -198,15 +198,21 @@ impl<T: Integer> SortedDisjoint<T> for core::iter::Once<core::ops::RangeInclusiv
 /// [multiway_union]: trait.MultiwaySortedDisjoint.html#method.union
 /// [multiway_intersection]: trait.MultiwaySortedDisjoint.html#method.intersection
 /// [multiway_symmetric_difference]: trait.MultiwaySortedDisjoint.html#method.symmetric_difference
-/// [`union_dyn!`]: macro.union_dyn.html
-/// [`intersection_dyn!`]: macro.intersection_dyn.html
-/// [`symmetric_difference_dyn!`]: macro.symmetric_difference_dyn.html
-///
+/// [union_dyn_macro]: macro@crate::union_dyn
+/// [intersection_dyn_macro]: macro@crate::intersection_dyn
+/// [symmetric_difference_dyn_macro]: macro@crate::symmetric_difference_dyn
 /// ## Performance
 ///
 /// Every operation is implemented as a single pass over the sorted & disjoint ranges, with minimal memory.
 ///
 /// This is true even when applying multiple operations. The last example below demonstrates this.
+///
+/// ## Standard Iterators
+///
+/// Many `core::iter` adapters preserve this marker trait when the inner iterator already
+/// implements it, including `filter`, `take_while`, `skip_while`, `fuse`, `skip`, `take`,
+/// and `peekable`. `empty`/`once` iterators and `Option`-based `flatten`/`flat_map` are also
+/// supported.
 ///
 /// ## Examples
 ///

--- a/src/sorted_disjoint.rs
+++ b/src/sorted_disjoint.rs
@@ -66,18 +66,17 @@ where
 
 // Check if core::iter::StepBy implements FusedIterator if it's inner is. Seems like it could be upstreamed
 // https://internals.rust-lang.org/t/implement-fusediterator-for-core-stepby/24074
-impl<T: Integer, I> SortedStarts<T> for core::iter::Fuse<core::iter::StepBy<I>> where
-    I: SortedStarts<T>
-{
-}
-impl<T: Integer, I> SortedDisjoint<T> for core::iter::Fuse<core::iter::StepBy<I>> where
-    I: SortedDisjoint<T>
-{
-}
+// impl<T: Integer, I> SortedStarts<T> for core::iter::Fuse<core::iter::StepBy<I>> where
+//     I: SortedStarts<T>
+// {
+// }
+// impl<T: Integer, I> SortedDisjoint<T> for core::iter::Fuse<core::iter::StepBy<I>> where
+//     I: SortedDisjoint<T>
+// {
+// }
 
-// Currently causes conflicts with StepBy and Skip... It doesn't make much sense tough, since SortedStarts are already fused
-// impl<T: Integer, I> SortedStarts<T> for core::iter::Fuse<I> where I: SortedStarts<T> {}
-// impl<T: Integer, I> SortedDisjoint<T> for core::iter::Fuse<I> where I: SortedDisjoint<T> {}
+impl<T: Integer, I> SortedStarts<T> for core::iter::Fuse<I> where I: SortedStarts<T> {}
+impl<T: Integer, I> SortedDisjoint<T> for core::iter::Fuse<I> where I: SortedDisjoint<T> {}
 
 impl<T: Integer, I> SortedStarts<T> for core::iter::Skip<I> where I: SortedStarts<T> {}
 impl<T: Integer, I> SortedDisjoint<T> for core::iter::Skip<I> where I: SortedDisjoint<T> {}
@@ -908,7 +907,7 @@ mod tests {
             .filter(|_| true)
             .skip_while(|_| false)
             .take_while(|_| true)
-            .step_by(1)
+            //.step_by(1)
             .fuse()
             .skip(0)
             .peekable();

--- a/src/sorted_disjoint.rs
+++ b/src/sorted_disjoint.rs
@@ -45,7 +45,7 @@ where
 
 impl<T: Integer, I, P> SortedDisjoint<T> for core::iter::TakeWhile<I, P>
 where
-    I: SortedStarts<T>,
+    I: SortedDisjoint<T>,
     P: FnMut(&I::Item) -> bool,
 {
 }
@@ -59,8 +59,45 @@ where
 
 impl<T: Integer, I, P> SortedDisjoint<T> for core::iter::SkipWhile<I, P>
 where
-    I: SortedStarts<T>,
+    I: SortedDisjoint<T>,
     P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T, I> SortedStarts<T> for core::iter::Flatten<core::option::IntoIter<I>>
+where
+    T: Integer,
+    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
+    I: SortedStarts<T>,
+{
+}
+
+impl<T, I> SortedDisjoint<T> for core::iter::Flatten<core::option::IntoIter<I>>
+where
+    T: Integer,
+    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
+    I: SortedDisjoint<T>,
+{
+}
+impl<T, I, IInner, TMap> SortedStarts<T>
+    for core::iter::FlatMap<core::option::IntoIter<I>, IInner, TMap>
+where
+    T: Integer,
+    IInner: SortedStarts<T>,
+    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
+    I: SortedStarts<T>,
+    TMap: FnMut(I) -> IInner,
+{
+}
+
+impl<T, I, IInner, TMap> SortedDisjoint<T>
+    for core::iter::FlatMap<core::option::IntoIter<I>, IInner, TMap>
+where
+    T: Integer,
+    IInner: SortedDisjoint<T>,
+    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
+    I: SortedStarts<T>,
+    TMap: FnMut(I) -> IInner,
 {
 }
 
@@ -904,13 +941,14 @@ mod tests {
         let a = core::iter::empty::<RangeInclusive<u64>>();
         #[allow(clippy::iter_skip_zero)]
         let b = core::iter::once(10u64..=20)
-            .filter(|_| true)
             .skip_while(|_| false)
             .take_while(|_| true)
             //.step_by(1)
             .fuse()
             .skip(0)
             .peekable();
+        #[allow(clippy::iter_on_single_items)]
+        let b = Some(b).into_iter().flat_map(|x| x.filter(|_| true));
         assert_eq!(Some(10u64..=20), a.union(b).next());
     }
 }

--- a/src/sorted_disjoint.rs
+++ b/src/sorted_disjoint.rs
@@ -67,7 +67,6 @@ where
 impl<T, I> SortedStarts<T> for core::iter::Flatten<core::option::IntoIter<I>>
 where
     T: Integer,
-    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
     I: SortedStarts<T>,
 {
 }
@@ -75,7 +74,6 @@ where
 impl<T, I> SortedDisjoint<T> for core::iter::Flatten<core::option::IntoIter<I>>
 where
     T: Integer,
-    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
     I: SortedDisjoint<T>,
 {
 }
@@ -84,7 +82,6 @@ impl<T, I, IInner, TMap> SortedStarts<T>
 where
     T: Integer,
     IInner: SortedStarts<T>,
-    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
     I: SortedStarts<T>,
     TMap: FnMut(I) -> IInner,
 {
@@ -95,12 +92,14 @@ impl<T, I, IInner, TMap> SortedDisjoint<T>
 where
     T: Integer,
     IInner: SortedDisjoint<T>,
-    Self: FusedIterator + Iterator<Item = RangeInclusive<T>>,
-    I: SortedStarts<T>,
+    I: SortedDisjoint<T>,
     TMap: FnMut(I) -> IInner,
 {
 }
 
+// Potential future support for core::iter::StepBy once it implements FusedIterator:
+// https://internals.rust-lang.org/t/implement-fusediterator-for-core-stepby/24074
+//
 // Check if core::iter::StepBy implements FusedIterator if it's inner is. Seems like it could be upstreamed
 // https://internals.rust-lang.org/t/implement-fusediterator-for-core-stepby/24074
 // impl<T: Integer, I> SortedStarts<T> for core::iter::Fuse<core::iter::StepBy<I>> where

--- a/src/sorted_disjoint.rs
+++ b/src/sorted_disjoint.rs
@@ -22,6 +22,78 @@ use crate::{
 /// that are not necessarily disjoint. The ranges are non-empty.
 pub trait SortedStarts<T: Integer>: Iterator<Item = RangeInclusive<T>> + FusedIterator {}
 
+impl<T: Integer, I, P> SortedStarts<T> for core::iter::Filter<I, P>
+where
+    I: SortedStarts<T>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T: Integer, I, P> SortedDisjoint<T> for core::iter::Filter<I, P>
+where
+    I: SortedDisjoint<T>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T: Integer, I, P> SortedStarts<T> for core::iter::TakeWhile<I, P>
+where
+    I: SortedStarts<T>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T: Integer, I, P> SortedDisjoint<T> for core::iter::TakeWhile<I, P>
+where
+    I: SortedStarts<T>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T: Integer, I, P> SortedStarts<T> for core::iter::SkipWhile<I, P>
+where
+    I: SortedStarts<T>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T: Integer, I, P> SortedDisjoint<T> for core::iter::SkipWhile<I, P>
+where
+    I: SortedStarts<T>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+// Check if core::iter::StepBy implements FusedIterator if it's inner is. Seems like it could be upstreamed
+// https://internals.rust-lang.org/t/implement-fusediterator-for-core-stepby/24074
+impl<T: Integer, I> SortedStarts<T> for core::iter::Fuse<core::iter::StepBy<I>> where
+    I: SortedStarts<T>
+{
+}
+impl<T: Integer, I> SortedDisjoint<T> for core::iter::Fuse<core::iter::StepBy<I>> where
+    I: SortedDisjoint<T>
+{
+}
+
+// Currently causes conflicts with StepBy and Skip... It doesn't make much sense tough, since SortedStarts are already fused
+// impl<T: Integer, I> SortedStarts<T> for core::iter::Fuse<I> where I: SortedStarts<T> {}
+// impl<T: Integer, I> SortedDisjoint<T> for core::iter::Fuse<I> where I: SortedDisjoint<T> {}
+
+impl<T: Integer, I> SortedStarts<T> for core::iter::Skip<I> where I: SortedStarts<T> {}
+impl<T: Integer, I> SortedDisjoint<T> for core::iter::Skip<I> where I: SortedDisjoint<T> {}
+
+impl<T: Integer, I> SortedStarts<T> for core::iter::Take<I> where I: SortedStarts<T> {}
+impl<T: Integer, I> SortedDisjoint<T> for core::iter::Take<I> where I: SortedDisjoint<T> {}
+
+impl<T: Integer, I> SortedStarts<T> for core::iter::Peekable<I> where I: SortedStarts<T> {}
+impl<T: Integer, I> SortedDisjoint<T> for core::iter::Peekable<I> where I: SortedDisjoint<T> {}
+
+impl<T: Integer> SortedStarts<T> for core::iter::Empty<core::ops::RangeInclusive<T>> {}
+impl<T: Integer> SortedDisjoint<T> for core::iter::Empty<core::ops::RangeInclusive<T>> {}
+
+impl<T: Integer> SortedStarts<T> for core::iter::Once<core::ops::RangeInclusive<T>> {}
+impl<T: Integer> SortedDisjoint<T> for core::iter::Once<core::ops::RangeInclusive<T>> {}
+
 /// Marks iterators that provide ranges that are sorted by start and disjoint. Set operations on
 /// iterators that implement this trait can be performed in linear time.
 ///
@@ -823,3 +895,23 @@ impl_sorted_traits_and_ops!(RangeValuesToRangesIter<T, VR, I>, VR: ValueRef, I: 
 impl_sorted_traits_and_ops!(SymDiffIter<T, I>, I: SortedStarts<T>);
 impl_sorted_traits_and_ops!(UnionIter<T, I>, I: SortedStarts<T>);
 impl_sorted_traits_and_ops!(RangeOnce<T>, 'ignore);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_union_std_iters() {
+        let a = core::iter::empty::<RangeInclusive<u64>>();
+        #[allow(clippy::iter_skip_zero)]
+        let b = core::iter::once(10u64..=20)
+            .filter(|_| true)
+            .skip_while(|_| false)
+            .take_while(|_| true)
+            .step_by(1)
+            .fuse()
+            .skip(0)
+            .peekable();
+        assert_eq!(Some(10u64..=20), a.union(b).next());
+    }
+}

--- a/src/sorted_disjoint_map.rs
+++ b/src/sorted_disjoint_map.rs
@@ -65,7 +65,7 @@ impl<T, VR, I, P> SortedDisjointMap<T, VR> for core::iter::TakeWhile<I, P>
 where
     T: Integer,
     VR: ValueRef,
-    I: SortedStartsMap<T, VR>,
+    I: SortedDisjointMap<T, VR>,
     P: FnMut(&I::Item) -> bool,
 {
 }
@@ -83,7 +83,7 @@ impl<T, VR, I, P> SortedDisjointMap<T, VR> for core::iter::SkipWhile<I, P>
 where
     T: Integer,
     VR: ValueRef,
-    I: SortedStartsMap<T, VR>,
+    I: SortedDisjointMap<T, VR>,
     P: FnMut(&I::Item) -> bool,
 {
 }
@@ -180,6 +180,47 @@ where
 {
 }
 
+impl<T, VR, I, IInner, TMap> SortedStartsMap<T, VR>
+    for core::iter::FlatMap<core::option::IntoIter<I>, IInner, TMap>
+where
+    T: Integer,
+    VR: ValueRef,
+    IInner: SortedStartsMap<T, VR>,
+    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
+    I: SortedStartsMap<T, VR>,
+    TMap: FnMut(I) -> IInner,
+{
+}
+
+impl<T, VR, I> SortedStartsMap<T, VR> for core::iter::Flatten<core::option::IntoIter<I>>
+where
+    T: Integer,
+    VR: ValueRef,
+    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
+    I: SortedStartsMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedDisjointMap<T, VR> for core::iter::Flatten<core::option::IntoIter<I>>
+where
+    T: Integer,
+    VR: ValueRef,
+    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
+    I: SortedDisjointMap<T, VR>,
+{
+}
+
+impl<T, VR, I, IInner, TMap> SortedDisjointMap<T, VR>
+    for core::iter::FlatMap<core::option::IntoIter<I>, IInner, TMap>
+where
+    T: Integer,
+    VR: ValueRef,
+    IInner: SortedDisjointMap<T, VR>,
+    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
+    I: SortedStartsMap<T, VR>,
+    TMap: FnMut(I) -> IInner,
+{
+}
 /// Used internally by [`UnionIterMap`] and [`SymDiffIterMap`].
 pub trait PrioritySortedStartsMap<T, VR>: Iterator<Item = Priority<T, VR>> + FusedIterator
 where
@@ -1160,12 +1201,15 @@ mod tests {
         let a = core::iter::empty::<(RangeInclusive<u64>, &&str)>();
         #[allow(clippy::iter_skip_zero)]
         let b = core::iter::once((10u64..=20, &"a"))
-            .filter(|_| true)
             .skip_while(|_| false)
             .take_while(|_| true)
             .fuse()
             .skip(0)
             .peekable();
+        #[allow(clippy::iter_on_single_items)]
+        let b = Some(b).into_iter().flat_map(|x| x.filter(|_| true));
+        #[allow(clippy::iter_on_single_items)]
+        let b = Some(b).into_iter().flatten();
         assert_eq!(Some((10u64..=20, &"a")), a.union(b).next());
     }
 }

--- a/src/sorted_disjoint_map.rs
+++ b/src/sorted_disjoint_map.rs
@@ -321,6 +321,13 @@ where
 ///
 /// This is true even when applying multiple operations. The last example below demonstrates this.
 ///
+/// ## Standard Iterators
+///
+/// Many `core::iter` adapters preserve this marker trait when the inner iterator already
+/// implements it, including `filter`, `take_while`, `skip_while`, `fuse`, `skip`, `take`,
+/// and `peekable`. `empty`/`once` iterators and `Option`-based `flatten`/`flat_map` are also
+/// supported.
+///
 /// ## Examples
 ///
 /// ```

--- a/src/sorted_disjoint_map.rs
+++ b/src/sorted_disjoint_map.rs
@@ -34,6 +34,152 @@ where
 {
 }
 
+impl<T, VR, I, P> SortedStartsMap<T, VR> for core::iter::Filter<I, P>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T, VR, I, P> SortedDisjointMap<T, VR> for core::iter::Filter<I, P>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedDisjointMap<T, VR>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T, VR, I, P> SortedStartsMap<T, VR> for core::iter::TakeWhile<I, P>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T, VR, I, P> SortedDisjointMap<T, VR> for core::iter::TakeWhile<I, P>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T, VR, I, P> SortedStartsMap<T, VR> for core::iter::SkipWhile<I, P>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T, VR, I, P> SortedDisjointMap<T, VR> for core::iter::SkipWhile<I, P>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+    P: FnMut(&I::Item) -> bool,
+{
+}
+
+impl<T, VR, I> SortedStartsMap<T, VR> for core::iter::Fuse<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedDisjointMap<T, VR> for core::iter::Fuse<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedDisjointMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedStartsMap<T, VR> for core::iter::Skip<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedDisjointMap<T, VR> for core::iter::Skip<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedDisjointMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedStartsMap<T, VR> for core::iter::Take<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedDisjointMap<T, VR> for core::iter::Take<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedDisjointMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedStartsMap<T, VR> for core::iter::Peekable<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedStartsMap<T, VR>,
+{
+}
+
+impl<T, VR, I> SortedDisjointMap<T, VR> for core::iter::Peekable<I>
+where
+    T: Integer,
+    VR: ValueRef,
+    I: SortedDisjointMap<T, VR>,
+{
+}
+
+impl<T, VR> SortedStartsMap<T, VR> for core::iter::Empty<(core::ops::RangeInclusive<T>, VR)>
+where
+    T: Integer,
+    VR: ValueRef,
+{
+}
+
+impl<T, VR> SortedDisjointMap<T, VR> for core::iter::Empty<(core::ops::RangeInclusive<T>, VR)>
+where
+    T: Integer,
+    VR: ValueRef,
+{
+}
+
+impl<T, VR> SortedStartsMap<T, VR> for core::iter::Once<(core::ops::RangeInclusive<T>, VR)>
+where
+    T: Integer,
+    VR: ValueRef,
+{
+}
+
+impl<T, VR> SortedDisjointMap<T, VR> for core::iter::Once<(core::ops::RangeInclusive<T>, VR)>
+where
+    T: Integer,
+    VR: ValueRef,
+{
+}
+
 /// Used internally by [`UnionIterMap`] and [`SymDiffIterMap`].
 pub trait PrioritySortedStartsMap<T, VR>: Iterator<Item = Priority<T, VR>> + FusedIterator
 where
@@ -1004,3 +1150,22 @@ impl_sorted_map_traits_and_ops!(IntoRangeValuesIter<T, V>, V, Rc<V>, V: Eq + Clo
 impl_sorted_map_traits_and_ops!(RangeValuesIter<'a, T, V>, V, &'a V, 'a, V: Eq + Clone);
 impl_sorted_map_traits_and_ops!(SymDiffIterMap<T, VR, I>, VR::Value, VR, VR: ValueRef, I: PrioritySortedStartsMap<T, VR>);
 impl_sorted_map_traits_and_ops!(UnionIterMap<T, VR, I>, VR::Value, VR, VR: ValueRef, I: PrioritySortedStartsMap<T, VR>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_union_std_iters_map() {
+        let a = core::iter::empty::<(RangeInclusive<u64>, &&str)>();
+        #[allow(clippy::iter_skip_zero)]
+        let b = core::iter::once((10u64..=20, &"a"))
+            .filter(|_| true)
+            .skip_while(|_| false)
+            .take_while(|_| true)
+            .fuse()
+            .skip(0)
+            .peekable();
+        assert_eq!(Some((10u64..=20, &"a")), a.union(b).next());
+    }
+}

--- a/src/sorted_disjoint_map.rs
+++ b/src/sorted_disjoint_map.rs
@@ -186,7 +186,6 @@ where
     T: Integer,
     VR: ValueRef,
     IInner: SortedStartsMap<T, VR>,
-    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
     I: SortedStartsMap<T, VR>,
     TMap: FnMut(I) -> IInner,
 {
@@ -196,7 +195,6 @@ impl<T, VR, I> SortedStartsMap<T, VR> for core::iter::Flatten<core::option::Into
 where
     T: Integer,
     VR: ValueRef,
-    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
     I: SortedStartsMap<T, VR>,
 {
 }
@@ -205,7 +203,6 @@ impl<T, VR, I> SortedDisjointMap<T, VR> for core::iter::Flatten<core::option::In
 where
     T: Integer,
     VR: ValueRef,
-    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
     I: SortedDisjointMap<T, VR>,
 {
 }
@@ -216,8 +213,7 @@ where
     T: Integer,
     VR: ValueRef,
     IInner: SortedDisjointMap<T, VR>,
-    Self: FusedIterator + Iterator<Item = (RangeInclusive<T>, VR)>,
-    I: SortedStartsMap<T, VR>,
+    I: SortedDisjointMap<T, VR>,
     TMap: FnMut(I) -> IInner,
 {
 }


### PR DESCRIPTION
 Implement SortedStarts and SortedDisjoint for std::iter::* types, which cannot break the invariants of SortedStarts or SortedDisjoint... This enables users of the library to use these operators, as demonstrated in the test.

- If you think this is nice, I'll implement this for sorted_disjoint_map too before the merge
- To my surprise, StepBy doesn't implement FusedIterator (I opened a discussion [here](https://internals.rust-lang.org/t/implement-fusediterator-for-core-stepby/24074)) if it could be added)
  --Would you be willing to drop the FusedIterator requirement of `SortedStarts` (breaking), if std::ops::Fused itself implements SortedStarts, if it's inner Iterator does?
